### PR TITLE
Add chunked file embedding support

### DIFF
--- a/KoalaWiki.sln
+++ b/KoalaWiki.sln
@@ -46,6 +46,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDeepWiki.CodeFoundation
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoalaWiki.Provider.MySQL", "Provider\KoalaWiki.Provider.MySQL\KoalaWiki.Provider.MySQL.csproj", "{E871B8A2-41D3-455A-AF74-6D324940A0AB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{14ABDC20-49E8-4B90-8C88-15C626194947}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoalaWiki.Tests", "tests\KoalaWiki.Tests\KoalaWiki.Tests.csproj", "{A8D9B0E4-326A-44D0-AA43-FACB45AE52F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,11 +92,15 @@ Global
 		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A8D9B0E4-326A-44D0-AA43-FACB45AE52F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A8D9B0E4-326A-44D0-AA43-FACB45AE52F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A8D9B0E4-326A-44D0-AA43-FACB45AE52F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A8D9B0E4-326A-44D0-AA43-FACB45AE52F8}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -105,9 +113,10 @@ Global
 		{72EF7275-1CC8-4609-8D4E-A77E5401C235} = {7F5745CD-DAE4-4C81-A675-B427B634EB17}
 		{D6C334AD-D67D-4E20-83C5-B5B47BCB886E} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
 		{F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9} = {DCEA2329-4E7D-4E3E-A507-DEE82B7F7D8A}
-		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8} = {F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9}
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
-	EndGlobalSection
+                {27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8} = {F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9}
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
+                {A8D9B0E4-326A-44D0-AA43-FACB45AE52F8} = {14ABDC20-49E8-4B90-8C88-15C626194947}
+        EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {57749C22-AF12-4764-9AD7-5327DB50CDE5}
 	EndGlobalSection

--- a/src/KoalaWiki/AssemblyInfo.cs
+++ b/src/KoalaWiki/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("KoalaWiki.Tests")]

--- a/src/KoalaWiki/KoalaWarehouse/PathInfo.cs
+++ b/src/KoalaWiki/KoalaWarehouse/PathInfo.cs
@@ -1,10 +1,14 @@
-﻿namespace KoalaWiki.KoalaWarehouse;
+namespace KoalaWiki.KoalaWarehouse;
 
 public class PathInfo
 {
-    public string Path { get; set; }
-
-    public string Name { get; set; }
-
-    public string Type { get; set; }
+    public string Path { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public int ChunkIndex { get; set; }
+    public int ChunkCount { get; set; }
+    public long ChunkOffset { get; set; }
+    public int ChunkLength { get; set; }
+    public bool IsChunked => ChunkCount > 1;
 }

--- a/src/KoalaWiki/Mem0/DefaultMem0ClientFactory.cs
+++ b/src/KoalaWiki/Mem0/DefaultMem0ClientFactory.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Linq;
+using System.Threading;
+using KoalaWiki.Options;
+
+namespace KoalaWiki.Mem0;
+
+public class DefaultMem0ClientFactory(IHttpClientFactory httpClientFactory) : IMem0ClientFactory
+{
+    public IMem0ClientAdapter CreateClient()
+    {
+        var httpClient = httpClientFactory.CreateClient(nameof(Mem0Rag));
+        httpClient.Timeout = TimeSpan.FromMinutes(600);
+        if (!httpClient.DefaultRequestHeaders.UserAgent.Any())
+        {
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("KoalaWiki", "1.0"));
+        }
+
+        var client = new Mem0.NET.Mem0Client(OpenAIOptions.Mem0ApiKey, OpenAIOptions.Mem0Endpoint, null, null, httpClient);
+        return new Mem0ClientAdapter(client, httpClient);
+    }
+
+    private sealed class Mem0ClientAdapter : IMem0ClientAdapter
+    {
+        private readonly Mem0.NET.Mem0Client _client;
+        private readonly HttpClient _httpClient;
+
+        public Mem0ClientAdapter(Mem0.NET.Mem0Client client, HttpClient httpClient)
+        {
+            _client = client;
+            _httpClient = httpClient;
+        }
+
+        public Task AddAsync(IList<Mem0.NET.Message> messages, string? userId, IDictionary<string, object>? metadata,
+            string? memoryType, CancellationToken cancellationToken)
+        {
+            return _client.AddAsync(messages, userId: userId, metadata: metadata, memoryType: memoryType,
+                cancellationToken: cancellationToken);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            switch (_client)
+            {
+                case IAsyncDisposable asyncDisposable:
+                    await asyncDisposable.DisposeAsync();
+                    break;
+                case IDisposable disposable:
+                    disposable.Dispose();
+                    break;
+            }
+
+            _httpClient.Dispose();
+        }
+    }
+}

--- a/src/KoalaWiki/Mem0/IMem0ClientFactory.cs
+++ b/src/KoalaWiki/Mem0/IMem0ClientFactory.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading;
+using Mem0.NET;
+
+namespace KoalaWiki.Mem0;
+
+public interface IMem0ClientAdapter : IAsyncDisposable
+{
+    Task AddAsync(IList<Message> messages, string? userId, IDictionary<string, object>? metadata,
+        string? memoryType, CancellationToken cancellationToken);
+}
+
+public interface IMem0ClientFactory
+{
+    IMem0ClientAdapter CreateClient();
+}

--- a/src/KoalaWiki/Mem0/Mem0ChunkUploader.cs
+++ b/src/KoalaWiki/Mem0/Mem0ChunkUploader.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using KoalaWiki.Domains;
+using KoalaWiki.Domains.Warehouse;
+using KoalaWiki.KoalaWarehouse;
+using Microsoft.Extensions.Logging;
+
+namespace KoalaWiki.Mem0;
+
+internal static class Mem0ChunkUploader
+{
+    public static async Task ProcessAsync(IMem0ClientAdapter client, IReadOnlyCollection<PathInfo> fileChunks,
+        Document document, Warehouse warehouse, string systemPrompt, CancellationToken cancellationToken,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(fileChunks);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(warehouse);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (string.IsNullOrWhiteSpace(systemPrompt))
+        {
+            throw new ArgumentException("System prompt cannot be null or empty", nameof(systemPrompt));
+        }
+
+        if (fileChunks.Count == 0)
+        {
+            return;
+        }
+
+        var orderedChunks = fileChunks
+            .OrderBy(chunk => chunk.ChunkIndex)
+            .ToList();
+
+        foreach (var chunk in orderedChunks)
+        {
+            var content = await ReadChunkContentAsync(chunk, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                logger.LogWarning("文件 {File} 分片 {Index}/{Count} 内容为空，跳过", chunk.Path,
+                    chunk.ChunkIndex + 1, chunk.ChunkCount);
+                continue;
+            }
+
+            string relativePath;
+            if (!string.IsNullOrWhiteSpace(document.GitPath))
+            {
+                relativePath = Path.GetRelativePath(document.GitPath, chunk.Path)
+                    .Replace('\\', '/');
+            }
+            else
+            {
+                relativePath = chunk.Path;
+            }
+
+            var userContent = $"```{relativePath}\n{content}\n```";
+
+            var messages = new List<Mem0.NET.Message>
+            {
+                new()
+                {
+                    Role = "system",
+                    Content = systemPrompt
+                },
+                new()
+                {
+                    Role = "user",
+                    Content = userContent
+                }
+            };
+
+            var metadata = BuildChunkMetadata(chunk, document.Id);
+            metadata["fileName"] = chunk.Name;
+            metadata["filePath"] = chunk.Path;
+            metadata["fileType"] = chunk.Type;
+            metadata["type"] = "code";
+
+            await client.AddAsync(messages, warehouse.Id, metadata, "procedural_memory", cancellationToken);
+        }
+    }
+
+    public static Dictionary<string, object> BuildChunkMetadata(PathInfo chunk, string documentId)
+    {
+        return new Dictionary<string, object>
+        {
+            { "fileSize", chunk.Size },
+            { "chunkIndex", chunk.ChunkIndex },
+            { "chunkCount", chunk.ChunkCount },
+            { "chunkOffset", chunk.ChunkOffset },
+            { "chunkLength", chunk.ChunkLength },
+            { "documentId", documentId }
+        };
+    }
+
+    public static async Task<string> ReadChunkContentAsync(PathInfo chunk, CancellationToken cancellationToken)
+    {
+        var effectiveLength = chunk.ChunkLength;
+        if (chunk.ChunkOffset + effectiveLength > chunk.Size)
+        {
+            effectiveLength = (int)Math.Max(0, chunk.Size - chunk.ChunkOffset);
+        }
+
+        if (effectiveLength <= 0)
+        {
+            return string.Empty;
+        }
+
+        if (chunk.ChunkOffset == 0 && effectiveLength >= chunk.Size)
+        {
+            return await File.ReadAllTextAsync(chunk.Path, cancellationToken);
+        }
+
+        await using var stream = new FileStream(chunk.Path, FileMode.Open, FileAccess.Read, FileShare.Read,
+            bufferSize: Math.Max(4096, effectiveLength), useAsync: true);
+        stream.Seek(chunk.ChunkOffset, SeekOrigin.Begin);
+
+        var buffer = new byte[effectiveLength];
+        var totalRead = 0;
+
+        while (totalRead < effectiveLength)
+        {
+            var bytesRead = await stream.ReadAsync(buffer.AsMemory(totalRead, effectiveLength - totalRead),
+                cancellationToken);
+            if (bytesRead == 0)
+            {
+                break;
+            }
+
+            totalRead += bytesRead;
+        }
+
+        return Encoding.UTF8.GetString(buffer, 0, totalRead);
+    }
+}

--- a/src/KoalaWiki/Program.cs
+++ b/src/KoalaWiki/Program.cs
@@ -157,6 +157,7 @@ builder.Services.AddSingleton<WarehouseProcessingTask>();
 builder.Services.AddHostedService<WarehouseProcessingTask>(provider =>
     provider.GetRequiredService<WarehouseProcessingTask>());
 builder.Services.AddHostedService<DataMigrationTask>();
+builder.Services.AddSingleton<IMem0ClientFactory, DefaultMem0ClientFactory>();
 builder.Services.AddHostedService<Mem0Rag>();
 
 builder.Services.AddDbContext(builder.Configuration);

--- a/tests/KoalaWiki.Tests/DocumentsHelperTests.cs
+++ b/tests/KoalaWiki.Tests/DocumentsHelperTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using KoalaWiki.Infrastructure;
+using KoalaWiki.KoalaWarehouse;
+using Xunit;
+
+namespace KoalaWiki.Tests;
+
+public class DocumentsHelperTests
+{
+    private const int ChunkSize = 800 * 1024;
+
+    [Fact]
+    public void ScanDirectory_SplitsLargeFilesIntoMultipleChunks()
+    {
+        using var tempDirectory = new TempDirectory();
+        var largeFilePath = Path.Combine(tempDirectory.DirectoryPath, "large.txt");
+        var largeContent = new string('A', ChunkSize + 200);
+        File.WriteAllText(largeFilePath, largeContent);
+
+        var files = DocumentsHelper.GetCatalogueFiles(tempDirectory.DirectoryPath)
+            .Where(info => info.Path == largeFilePath)
+            .OrderBy(info => info.ChunkIndex)
+            .ToList();
+
+        Assert.Equal(2, files.Count);
+
+        var firstChunk = files[0];
+        var secondChunk = files[1];
+
+        Assert.Equal(0, firstChunk.ChunkIndex);
+        Assert.Equal(2, firstChunk.ChunkCount);
+        Assert.Equal(0, firstChunk.ChunkOffset);
+        Assert.Equal(ChunkSize, firstChunk.ChunkLength);
+        Assert.Equal(largeContent.Length, firstChunk.Size);
+
+        Assert.Equal(1, secondChunk.ChunkIndex);
+        Assert.Equal(2, secondChunk.ChunkCount);
+        Assert.Equal(ChunkSize, secondChunk.ChunkOffset);
+        Assert.Equal(200, secondChunk.ChunkLength);
+        Assert.Equal(largeContent.Length, secondChunk.Size);
+    }
+
+    [Fact]
+    public void ScanDirectory_UsesSingleChunkForSmallFiles()
+    {
+        using var tempDirectory = new TempDirectory();
+        var filePath = Path.Combine(tempDirectory.DirectoryPath, "small.txt");
+        const string content = "hello";
+        File.WriteAllText(filePath, content);
+
+        var info = DocumentsHelper.GetCatalogueFiles(tempDirectory.DirectoryPath)
+            .Single(x => x.Path == filePath);
+
+        Assert.Equal(0, info.ChunkIndex);
+        Assert.Equal(1, info.ChunkCount);
+        Assert.Equal(0, info.ChunkOffset);
+        Assert.Equal(content.Length, info.ChunkLength);
+        Assert.Equal(content.Length, info.Size);
+    }
+
+}

--- a/tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj
+++ b/tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KoalaWiki\KoalaWiki.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/KoalaWiki.Tests/Mem0ChunkUploaderTests.cs
+++ b/tests/KoalaWiki.Tests/Mem0ChunkUploaderTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using KoalaWiki.Domains;
+using KoalaWiki.Domains.Warehouse;
+using KoalaWiki.Infrastructure;
+using KoalaWiki.KoalaWarehouse;
+using KoalaWiki.Mem0;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mem0.NET;
+using Xunit;
+
+namespace KoalaWiki.Tests;
+
+public class Mem0ChunkUploaderTests
+{
+    private const int ChunkSize = 800 * 1024;
+
+    [Fact]
+    public async Task ProcessAsync_UploadsAllChunksWithMetadata()
+    {
+        using var tempDirectory = new TempDirectory();
+        var filePath = Path.Combine(tempDirectory.DirectoryPath, "chunked.cs");
+        var contentBuilder = new StringBuilder();
+        contentBuilder.Append('B', ChunkSize);
+        contentBuilder.Append("// tail");
+        var fullContent = contentBuilder.ToString();
+        File.WriteAllText(filePath, fullContent);
+
+        var pathInfos = DocumentsHelper.GetCatalogueFiles(tempDirectory.DirectoryPath)
+            .Where(info => info.Path == filePath)
+            .OrderBy(info => info.ChunkIndex)
+            .ToList();
+
+        var document = new Document
+        {
+            Id = Guid.NewGuid().ToString(),
+            GitPath = tempDirectory.DirectoryPath,
+            WarehouseId = Guid.NewGuid().ToString()
+        };
+
+        var warehouse = new Warehouse
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Test Warehouse",
+            Description = string.Empty,
+            Address = string.Empty
+        };
+
+        var fakeClient = new FakeMem0ClientAdapter();
+        var systemPrompt = "system";
+
+        await Mem0ChunkUploader.ProcessAsync(fakeClient, pathInfos, document, warehouse, systemPrompt,
+            CancellationToken.None, NullLogger.Instance);
+
+        var orderedCalls = fakeClient.Calls
+            .OrderBy(call => (int)call.Metadata["chunkIndex"])
+            .ToList();
+
+        Assert.Equal(pathInfos.Count, orderedCalls.Count);
+
+        for (var i = 0; i < pathInfos.Count; i++)
+        {
+            var call = orderedCalls[i];
+            var chunk = pathInfos[i];
+
+            Assert.Equal(warehouse.Id, call.UserId);
+            Assert.Equal("procedural_memory", call.MemoryType);
+            Assert.Equal(systemPrompt, call.Messages[0].Content);
+            Assert.Equal(chunk.ChunkIndex, (int)call.Metadata["chunkIndex"]);
+            Assert.Equal(chunk.ChunkCount, (int)call.Metadata["chunkCount"]);
+            Assert.Equal(chunk.ChunkOffset, (long)call.Metadata["chunkOffset"]);
+            Assert.Equal(chunk.ChunkLength, (int)call.Metadata["chunkLength"]);
+
+            var userMessage = call.Messages[1].Content;
+            Assert.Contains(Path.GetFileName(filePath), userMessage);
+            var expectedChunkContent = await Mem0ChunkUploader.ReadChunkContentAsync(chunk, CancellationToken.None);
+            Assert.Contains(expectedChunkContent, userMessage);
+        }
+    }
+
+    private sealed class FakeMem0ClientAdapter : IMem0ClientAdapter
+    {
+        public List<CallRecord> Calls { get; } = new();
+
+        public Task AddAsync(IList<Message> messages, string? userId, IDictionary<string, object>? metadata,
+            string? memoryType, CancellationToken cancellationToken)
+        {
+            Calls.Add(new CallRecord(messages.ToList(), userId, metadata ?? new Dictionary<string, object>(), memoryType));
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    public sealed record CallRecord(List<Message> Messages, string? UserId, IDictionary<string, object> Metadata,
+        string? MemoryType);
+}

--- a/tests/KoalaWiki.Tests/TempDirectory.cs
+++ b/tests/KoalaWiki.Tests/TempDirectory.cs
@@ -1,0 +1,19 @@
+namespace KoalaWiki.Tests;
+
+public sealed class TempDirectory : IDisposable
+{
+    public string DirectoryPath { get; } = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    public TempDirectory()
+    {
+        Directory.CreateDirectory(DirectoryPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(DirectoryPath))
+        {
+            Directory.Delete(DirectoryPath, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `PathInfo` and `DocumentsHelper` to represent large files as sequential chunks instead of skipping them
- refactor Mem0 ingestion to stream chunked file uploads via an injectable client factory and chunk uploader helper
- add a KoalaWiki.Tests project covering chunk generation and Mem0 chunk processing regressions

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dba61a587c832ca17737596e606549