### PR TITLE
Introduce strongly typed catalogue generation workflow

### DIFF
--- a/KoalaWiki.sln
+++ b/KoalaWiki.sln
@@ -42,6 +42,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "framework", "framework", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7071FDA4-6C71-4832-B41C-D64FFBB2A64F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoalaWiki.Tests", "tests\\KoalaWiki.Tests\\KoalaWiki.Tests.csproj", "{65D682C6-0815-4488-AD51-0F7929F40507}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDeepWiki.CodeFoundation", "framework\src\OpenDeepWiki.CodeFoundation\OpenDeepWiki.CodeFoundation.csproj", "{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoalaWiki.Provider.MySQL", "Provider\KoalaWiki.Provider.MySQL\KoalaWiki.Provider.MySQL.csproj", "{E871B8A2-41D3-455A-AF74-6D324940A0AB}"
@@ -92,6 +96,10 @@ Global
 		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65D682C6-0815-4488-AD51-0F7929F40507}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65D682C6-0815-4488-AD51-0F7929F40507}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65D682C6-0815-4488-AD51-0F7929F40507}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65D682C6-0815-4488-AD51-0F7929F40507}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -107,6 +115,7 @@ Global
 		{F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9} = {DCEA2329-4E7D-4E3E-A507-DEE82B7F7D8A}
 		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8} = {F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9}
 		{E871B8A2-41D3-455A-AF74-6D324940A0AB} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
+		{65D682C6-0815-4488-AD51-0F7929F40507} = {7071FDA4-6C71-4832-B41C-D64FFBB2A64F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {57749C22-AF12-4764-9AD7-5327DB50CDE5}

--- a/src/KoalaWiki/KoalaWarehouse/Pipeline/Steps/DocumentStructureGenerationStep.cs
+++ b/src/KoalaWiki/KoalaWarehouse/Pipeline/Steps/DocumentStructureGenerationStep.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using KoalaWiki.Domains.DocumentFile;
 using KoalaWiki.Entities;
 using KoalaWiki.KoalaWarehouse.GenerateThinkCatalogue;
@@ -25,6 +26,16 @@ public sealed class DocumentStructureGenerationStep(ILogger<DocumentStructureGen
                 context.Catalogue ?? string.Empty,
                 context.Warehouse,
                 context.Classification).ConfigureAwait(false);
+
+            if (result == null)
+            {
+                throw new InvalidDataException("未能生成有效的文档目录结构。");
+            }
+
+            if (result.items == null || result.items.Count == 0)
+            {
+                throw new InvalidDataException("生成的文档目录为空。");
+            }
 
             var documentCatalogs = new List<DocumentCatalog>();
 

--- a/tests/KoalaWiki.Tests/GenerateThinkCatalogue/CatalogueFunctionTests.cs
+++ b/tests/KoalaWiki.Tests/GenerateThinkCatalogue/CatalogueFunctionTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using KoalaWiki.KoalaWarehouse;
+using KoalaWiki.KoalaWarehouse.GenerateThinkCatalogue;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace KoalaWiki.Tests.GenerateThinkCatalogue;
+
+public class CatalogueFunctionTests
+{
+    [Fact]
+    public void GenerateCatalogue_WithValidInput_StoresContent()
+    {
+        var catalogueFunction = new CatalogueFunction();
+        var catalogue = new DocumentResultCatalogue
+        {
+            items =
+            [
+                new DocumentResultCatalogueItem
+                {
+                    name = "root",
+                    title = "Root",
+                    prompt = "Describe the project entry point."
+                }
+            ]
+        };
+
+        var result = catalogueFunction.GenerateCatalogue(catalogue);
+
+        Assert.True(catalogueFunction.CatalogueGenerated);
+        Assert.Equal(JsonConvert.SerializeObject(catalogue, Formatting.None), catalogueFunction.Content);
+        Assert.Single(result.items);
+    }
+
+    [Fact]
+    public void GenerateCatalogue_MissingPrompt_Throws()
+    {
+        var catalogueFunction = new CatalogueFunction();
+        var catalogue = new DocumentResultCatalogue
+        {
+            items =
+            [
+                new DocumentResultCatalogueItem
+                {
+                    name = "root",
+                    title = "Root",
+                    prompt = string.Empty
+                }
+            ]
+        };
+
+        Assert.Throws<InvalidDataException>(() => catalogueFunction.GenerateCatalogue(catalogue));
+    }
+
+    [Fact]
+    public void GenerateCatalogue_CalledTwice_Throws()
+    {
+        var catalogueFunction = new CatalogueFunction();
+        var catalogue = new DocumentResultCatalogue
+        {
+            items =
+            [
+                new DocumentResultCatalogueItem
+                {
+                    name = "root",
+                    title = "Root",
+                    prompt = "Describe the project entry point."
+                }
+            ]
+        };
+
+        catalogueFunction.GenerateCatalogue(catalogue);
+
+        Assert.Throws<InvalidOperationException>(() => catalogueFunction.GenerateCatalogue(catalogue));
+    }
+}

--- a/tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj
+++ b/tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KoalaWiki\KoalaWiki.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a `catalog.GenerateCatalogue` kernel tool that validates input and persists the catalogue as a strongly typed `DocumentResultCatalogue`
- refactor the catalogue generation service to simplify the system reminder, enforce single tool usage, and add structured JSON validation plus fallback parsing and logging
- update document structure processing and register a new xUnit test project covering catalogue generation scenarios

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db7c51c330832ca4cf0e66ba38de6e