### PR TITLE
feat: enable multi-repository responses and rag search

### DIFF
--- a/KoalaWiki.sln
+++ b/KoalaWiki.sln
@@ -46,6 +46,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDeepWiki.CodeFoundation
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoalaWiki.Provider.MySQL", "Provider\KoalaWiki.Provider.MySQL\KoalaWiki.Provider.MySQL.csproj", "{E871B8A2-41D3-455A-AF74-6D324940A0AB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E7D2E272-A554-4D65-A410-BF0064B78F68}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoalaWiki.Tests", "tests\KoalaWiki.Tests\KoalaWiki.Tests.csproj", "{B97FEF7E-B192-4AF9-B798-79580A9ED931}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,18 +89,22 @@ Global
 		{A9C4E6B7-B9C3-6605-3477-4FA0194EDBA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A9C4E6B7-B9C3-6605-3477-4FA0194EDBA5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+                {27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B97FEF7E-B192-4AF9-B798-79580A9ED931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B97FEF7E-B192-4AF9-B798-79580A9ED931}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B97FEF7E-B192-4AF9-B798-79580A9ED931}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B97FEF7E-B192-4AF9-B798-79580A9ED931}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
 		{7542FEE4-8528-4C9D-A26B-8C1F4A24307C} = {7F5745CD-DAE4-4C81-A675-B427B634EB17}
 		{8E887B45-75E2-4264-B5DE-93C9E206495E} = {7F5745CD-DAE4-4C81-A675-B427B634EB17}
 		{E6A1B1C9-55F9-4568-9389-C16D47CFE798} = {7F5745CD-DAE4-4C81-A675-B427B634EB17}
@@ -105,9 +113,10 @@ Global
 		{72EF7275-1CC8-4609-8D4E-A77E5401C235} = {7F5745CD-DAE4-4C81-A675-B427B634EB17}
 		{D6C334AD-D67D-4E20-83C5-B5B47BCB886E} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
 		{F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9} = {DCEA2329-4E7D-4E3E-A507-DEE82B7F7D8A}
-		{27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8} = {F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9}
-		{E871B8A2-41D3-455A-AF74-6D324940A0AB} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
-	EndGlobalSection
+                {27B59BA7-49B8-4B9B-BDA2-9530DD2AE3B8} = {F39528D6-BAFE-4C38-B5C6-39CEA5B1BEA9}
+                {E871B8A2-41D3-455A-AF74-6D324940A0AB} = {E6A1B1C9-55F9-4568-9389-C16D47CFE798}
+                {B97FEF7E-B192-4AF9-B798-79580A9ED931} = {E7D2E272-A554-4D65-A410-BF0064B78F68}
+        EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {57749C22-AF12-4764-9AD7-5327DB50CDE5}
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -102,6 +102,39 @@ This way, OpenDeepWiki can serve as an MCPServer for other AI models to call, fa
 
 ---
 
+# Multi-Repository Responses Input
+
+You can now instruct the `/api/Responses` endpoint to analyze more than one repository in a single conversation. Add the optional `repositories` collection to the request payload to provide additional warehouses while keeping the legacy `organizationName`/`name` fields for backwards compatibility.
+
+```jsonc
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "content": "Explain how the web API authenticates users" }
+      ]
+    }
+  ],
+  "repositories": [
+    {
+      "warehouseId": "core-api",
+      "alias": "Core",
+      "prefix": "[core] "
+    },
+    {
+      "organizationName": "AIDotNet",
+      "name": "OpenDeepWiki",
+      "alias": "Docs"
+    }
+  ]
+}
+```
+
+Each repository entry may specify a direct `warehouseId` or fall back to the organization/name pair. Optional `alias` and `prefix` values help the assistant disambiguate catalogue sections inside the system prompt. When multiple repositories are supplied the service aggregates their directory trees, configures the RAG tool for all warehouse IDs, and surfaces GitHub/Gitee tool plugins with unique labels.
+
+---
+
 # 🚀 Quick Start
 
 1. Clone the repository

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,6 +102,39 @@ OpenDeepWiki支持MCP协议：
 
 ---
 
+# 多仓库 Responses 输入示例
+
+现在可以在一次会话中让 `/api/Responses` 同时分析多个知识仓库。请求体中新增的 `repositories` 字段与原有的 `organizationName`/`name` 字段兼容，可按需继续使用旧格式。
+
+```jsonc
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "content": "请比较核心服务和文档站的鉴权差异" }
+      ]
+    }
+  ],
+  "repositories": [
+    {
+      "warehouseId": "core-api",
+      "alias": "核心服务",
+      "prefix": "[core] "
+    },
+    {
+      "organizationName": "AIDotNet",
+      "name": "OpenDeepWiki",
+      "alias": "文档站"
+    }
+  ]
+}
+```
+
+每个仓库可以直接提供 `warehouseId`，或继续使用组织名+仓库名的方式。可选的 `alias` 和 `prefix` 会在系统提示词中帮助区分不同仓库的目录。启用多仓模式后，服务会自动聚合目录结构、为所有仓库配置 RAG 搜索，并为 GitHub/Gitee 插件添加唯一标识。
+
+---
+
 # 🚀 快速开始 Quick Start
 
 1. 克隆仓库

--- a/src/KoalaWiki/Dto/ResponsesInput.cs
+++ b/src/KoalaWiki/Dto/ResponsesInput.cs
@@ -16,6 +16,11 @@ public class ResponsesInput
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// 多仓库选择器（可选）。当提供多个仓库时，服务将自动切换至多仓模式。
+    /// </summary>
+    public List<RepositorySelector>? Repositories { get; set; }
+
+    /// <summary>
     /// 应用ID
     /// </summary>
     public string? AppId { get; set; }
@@ -24,6 +29,34 @@ public class ResponsesInput
     /// 是否开启深度研究
     /// </summary>
     public bool DeepResearch { get; set; } = false;
+}
+
+public class RepositorySelector
+{
+    /// <summary>
+    /// 仓库在系统中的唯一标识，可选。当提供时将优先于组织名和仓库名匹配。
+    /// </summary>
+    public string? WarehouseId { get; set; }
+
+    /// <summary>
+    /// 组织名（与旧字段保持一致以兼容旧版调用）。
+    /// </summary>
+    public string OrganizationName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 仓库名称。
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 可选的别名，在多仓模式下用于展示及提示信息。
+    /// </summary>
+    public string? Alias { get; set; }
+
+    /// <summary>
+    /// 目录展示前缀（例如 "repo-a:"），帮助区分不同仓库的目录结构。
+    /// </summary>
+    public string? Prefix { get; set; }
 }
 
 public class ResponsesMessageInput

--- a/src/KoalaWiki/Tools/RagTool.cs
+++ b/src/KoalaWiki/Tools/RagTool.cs
@@ -1,21 +1,61 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Mem0.NET;
 
 namespace KoalaWiki.Tools;
 
-public class RagTool(string warehouseId)
+public class RagTool : IDisposable, IAsyncDisposable
 {
-    private readonly Mem0Client _mem0Client = new(OpenAIOptions.Mem0ApiKey, OpenAIOptions.Mem0Endpoint, null, null,
-        new HttpClient()
+    private readonly IReadOnlyList<string> _warehouseIds;
+    private readonly Mem0Client? _mem0Client;
+    private readonly Func<SearchRequest, Task<object?>> _searchExecutor;
+
+    public RagTool(string warehouseId)
+        : this(new[] { warehouseId })
+    {
+    }
+
+    public RagTool(IEnumerable<string> warehouseIds, Func<SearchRequest, Task<object?>>? searchExecutor = null)
+    {
+        if (warehouseIds == null)
         {
-            Timeout = TimeSpan.FromMinutes(600),
-            DefaultRequestHeaders =
-            {
-                UserAgent = { new ProductInfoHeaderValue("KoalaWiki", "1.0") }
-            }
-        });
+            throw new ArgumentNullException(nameof(warehouseIds));
+        }
+
+        var distinctIds = warehouseIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (distinctIds.Count == 0)
+        {
+            throw new ArgumentException("At least one warehouseId must be provided", nameof(warehouseIds));
+        }
+
+        _warehouseIds = distinctIds;
+
+        if (searchExecutor != null)
+        {
+            _searchExecutor = searchExecutor;
+        }
+        else
+        {
+            _mem0Client = new Mem0Client(OpenAIOptions.Mem0ApiKey, OpenAIOptions.Mem0Endpoint, null, null,
+                new HttpClient()
+                {
+                    Timeout = TimeSpan.FromMinutes(600),
+                    DefaultRequestHeaders =
+                    {
+                        UserAgent = { new ProductInfoHeaderValue("KoalaWiki", "1.0") }
+                    }
+                });
+
+            _searchExecutor = async request => await _mem0Client.SearchAsync(request);
+        }
+    }
 
 
     [KernelFunction("rag_search"), Description("Search and retrieve relevant code or documentation content from the current repository index using specific keywords.")]
@@ -27,14 +67,71 @@ public class RagTool(string warehouseId)
         [Description("Minimum relevance threshold for vector search results, ranging from 0 to 1. Default is 0.3. Higher values (e.g., 0.7) return more precise matches, while lower values provide more varied results.")]
         double minRelevance = 0.3)
     {
-        var result = await _mem0Client.SearchAsync(new SearchRequest()
+        var responses = await Task.WhenAll(
+            _warehouseIds.Select(id => ExecuteSearchAsync(id, query, limit, minRelevance)));
+
+        if (responses.Length == 1)
+        {
+            return JsonSerializer.Serialize(responses[0].Result, JsonSerializerOptions.Web);
+        }
+
+        var resultsArray = new JsonArray();
+        foreach (var response in responses)
+        {
+            JsonNode? resultNode = null;
+            if (response.Result != null)
+            {
+                resultNode = JsonSerializer.SerializeToNode(response.Result, JsonSerializerOptions.Web);
+            }
+
+            var entry = new JsonObject
+            {
+                ["warehouseId"] = response.WarehouseId,
+            };
+
+            if (resultNode != null)
+            {
+                entry["result"] = resultNode;
+            }
+
+            resultsArray.Add(entry);
+        }
+
+        var payload = new JsonObject
+        {
+            ["query"] = query,
+            ["limit"] = limit,
+            ["minRelevance"] = minRelevance,
+            ["totalRepositories"] = responses.Length,
+            ["results"] = resultsArray
+        };
+
+        return payload.ToJsonString(JsonSerializerOptions.Web);
+    }
+
+    private async Task<(string WarehouseId, object? Result)> ExecuteSearchAsync(string warehouseId, string query,
+        int limit, double minRelevance)
+    {
+        var request = new SearchRequest()
         {
             Query = query,
             UserId = warehouseId,
             Threshold = minRelevance,
             Limit = limit,
-        });
+        };
 
-        return JsonSerializer.Serialize(result, JsonSerializerOptions.Web);
+        var result = await _searchExecutor(request);
+        return (warehouseId, result);
+    }
+
+    public void Dispose()
+    {
+        _mem0Client?.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj
+++ b/tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/KoalaWiki/KoalaWiki.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/KoalaWiki.Tests/RagToolTests.cs
+++ b/tests/KoalaWiki.Tests/RagToolTests.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using KoalaWiki.Tools;
+using Mem0.NET;
+using Xunit;
+
+namespace KoalaWiki.Tests;
+
+public class RagToolTests
+{
+    [Fact]
+    public async Task SearchAsync_WithMultipleWarehouses_MergesResults()
+    {
+        var capturedRequests = new List<SearchRequest>();
+        var responses = new Dictionary<string, object?>
+        {
+            ["repo-a"] = new { hits = new[] { "A" } },
+            ["repo-b"] = new { hits = new[] { "B" } }
+        };
+
+        await using var rag = new RagTool(new[] { "repo-a", "repo-b" }, request =>
+        {
+            capturedRequests.Add(request);
+            return Task.FromResult(responses[request.UserId]);
+        });
+
+        var json = await rag.SearchAsync("test query", limit: 3, minRelevance: 0.5);
+        var node = JsonNode.Parse(json)!.AsObject();
+
+        Assert.Equal(2, node["totalRepositories"]!.GetValue<int>());
+        Assert.Equal("test query", node["query"]!.GetValue<string>());
+        var results = node["results"]!.AsArray();
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, item =>
+            item!["warehouseId"]!.GetValue<string>() == "repo-a" &&
+            item["result"]!["hits"]![0]!.GetValue<string>() == "A");
+        Assert.Contains(results, item =>
+            item!["warehouseId"]!.GetValue<string>() == "repo-b" &&
+            item["result"]!["hits"]![0]!.GetValue<string>() == "B");
+        Assert.Equal(new[] { "repo-a", "repo-b" }, capturedRequests.Select(r => r.UserId).ToArray());
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithSingleWarehouse_ReturnsOriginalPayload()
+    {
+        await using var rag = new RagTool(new[] { "solo" }, request =>
+        {
+            return Task.FromResult<object?>(new { hits = new[] { request.UserId } });
+        });
+
+        var json = await rag.SearchAsync("solo-query");
+        var node = JsonNode.Parse(json)!.AsObject();
+
+        Assert.Equal("solo", node["hits"]![0]!.GetValue<string>());
+    }
+}


### PR DESCRIPTION
## Summary
- extend ResponsesInput and ResponsesService to load multiple warehouses, aggregate catalogues, and expose multi-repo prompts
- update RagTool to query several warehouse ids in one call and add unit tests covering the aggregation behaviour
- document the new multi-repository request payload in both README files and register the new test project in the solution

## Testing
- dotnet test tests/KoalaWiki.Tests/KoalaWiki.Tests.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db7c66d66c832c9e6dc002636e8690